### PR TITLE
Fixed Duplicate `XamlCompilation` attribute error

### DIFF
--- a/Final/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/Final/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/11-DownloadPhotosToMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/11-DownloadPhotosToMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/12-ShowPhotosOnMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/12-ShowPhotosOnMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/4A-CreateLoginPage/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/4A-CreateLoginPage/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/4B-PersistingTheLogin/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/4B-PersistingTheLogin/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/5-WireUpTheCamera/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/5-WireUpTheCamera/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/6-DetectFaces/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/6-DetectFaces/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/8-FunctionToSavePhotos/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/8-FunctionToSavePhotos/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }

--- a/FinishedWorkshopSteps/9-BlobStorageTrigger/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
+++ b/FinishedWorkshopSteps/9-BlobStorageTrigger/HappyXamDevs/HappyXamDevs/HappyXamDevs/App.xaml.cs
@@ -1,9 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using Xamarin.Forms.Xaml;
-
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 namespace HappyXamDevs
 {
@@ -14,13 +11,14 @@ namespace HappyXamDevs
             InitializeComponent();
 
             var navigationPage = new Xamarin.Forms.NavigationPage(new MainPage());
-            MainPage = navigationPage;
 
             navigationPage.BarBackgroundColor = (Color)Resources["CoolPurple"];
             navigationPage.BarTextColor = Color.White;
 
             navigationPage.On<iOS>().SetPrefersLargeTitles(true);
             navigationPage.On<iOS>().SetUseSafeArea(true);
+
+            MainPage = navigationPage;
         }
     }
 }


### PR DESCRIPTION
Removed `[assembly: XamlCompilation(XamlCompilationOptions.Compile)]` from `App.xaml.cs` because the new templates provides the same assebly attribute in the `AssemblyInfo.cs`