### PR TITLE
Fixed UWP Authentication

### DIFF
--- a/Final/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/Final/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/Final/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/Final/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/11-DownloadPhotosToMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/11-DownloadPhotosToMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/11-DownloadPhotosToMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/11-DownloadPhotosToMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/12-ShowPhotosOnMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/12-ShowPhotosOnMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/12-ShowPhotosOnMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/12-ShowPhotosOnMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/3-CreateAnAzureServiceInTheMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/3-CreateAnAzureServiceInTheMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/3-CreateAnAzureServiceInTheMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/3-CreateAnAzureServiceInTheMobileApp/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/4A-CreateLoginPage/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/4A-CreateLoginPage/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/4A-CreateLoginPage/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/4A-CreateLoginPage/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/4B-PersistingTheLogin/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/4B-PersistingTheLogin/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/4B-PersistingTheLogin/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/4B-PersistingTheLogin/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/5-WireUpTheCamera/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/5-WireUpTheCamera/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/5-WireUpTheCamera/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/5-WireUpTheCamera/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/6-DetectFaces/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/6-DetectFaces/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/6-DetectFaces/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/6-DetectFaces/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/8-FunctionToSavePhotos/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/8-FunctionToSavePhotos/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/8-FunctionToSavePhotos/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/8-FunctionToSavePhotos/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }

--- a/FinishedWorkshopSteps/9-BlobStorageTrigger/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
+++ b/FinishedWorkshopSteps/9-BlobStorageTrigger/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/App.xaml.cs
@@ -48,7 +48,7 @@ namespace HappyXamDevs.UWP
 
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            if (args.Kind == ActivationKind.Protocol)
+            if (args.Kind is ActivationKind.Protocol)
             {
                 var protocolArgs = args as ProtocolActivatedEventArgs;
                 var content = Window.Current.Content as Frame;

--- a/FinishedWorkshopSteps/9-BlobStorageTrigger/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
+++ b/FinishedWorkshopSteps/9-BlobStorageTrigger/HappyXamDevs/HappyXamDevs/HappyXamDevs.UWP/Services/AzureService.cs
@@ -9,7 +9,7 @@ namespace HappyXamDevs.UWP.Services
         protected override Task AuthenticateUser()
         {
             return Client.LoginAsync(MobileServiceAuthenticationProvider.Facebook,
-                                    AzureAppName);
+                                    "happyxamdevs");
         }
     }
 }


### PR DESCRIPTION
HappyXamDevs.UWP.Services.AzureService was incorrectly using `AppName` for the `urlScheme`. Changing it to `"xamhappydevs" fixed the auth flow.